### PR TITLE
Assume semver-early for Java, and pvp for Scala during lint

### DIFF
--- a/multideps/src/main/scala/multideps/commands/ExportCommand.scala
+++ b/multideps/src/main/scala/multideps/commands/ExportCommand.scala
@@ -10,7 +10,6 @@ import java.time.Duration
 import java.{util => ju}
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 
@@ -29,9 +28,7 @@ import multideps.resolvers.Sha256
 import coursier.cache.ArtifactError
 import coursier.cache.CachePolicy
 import coursier.cache.FileCache
-import coursier.core.Dependency
 import coursier.core.Resolution
-import coursier.core.Version
 import coursier.util.Artifact
 import coursier.util.Task
 import coursier.version.VersionCompatibility
@@ -285,6 +282,7 @@ case class ExportCommand(
     }
   }
 
+  /*
   private def reconcileVersions(
       versions: collection.Set[Dependency],
       compat: VersionCompatibility
@@ -309,6 +307,7 @@ case class ExportCommand(
     }
     retained.keys.toList
   }
+   */
 
   private def withThreadPool[T](fn: CoursierThreadPools => T): T = {
     val threads = new CoursierThreadPools()

--- a/multideps/src/main/scala/multideps/diagnostics/ConflictingTransitiveDependencyDiagnostic.scala
+++ b/multideps/src/main/scala/multideps/diagnostics/ConflictingTransitiveDependencyDiagnostic.scala
@@ -34,7 +34,7 @@ class ConflictingTransitiveDependencyDiagnostic(
         "add 'dependencies = ''' to the root dependencies OR add 'targets' to the transitive dependency."
     val rootDependnecies = pretty(roots.distinct.take(5).map(_.repr))
     s"""transitive dependency '${module.repr}' has conflicting versions.
-       |    resolved versions:${pretty(transitiveVersions)}
+       |    found versions:${pretty(transitiveVersions)}
        |    declared versions:${pretty(declaredVersions)}
        |    root dependencies:${rootDependnecies}
        |  To fix this problem, $toFix

--- a/multideps/src/main/scala/multideps/outputs/ResolutionIndex.scala
+++ b/multideps/src/main/scala/multideps/outputs/ResolutionIndex.scala
@@ -26,7 +26,15 @@ final case class ResolutionIndex(
           .getOrElse(module, Nil)
           .headOption
           .flatMap(_.versionScheme)
-          .getOrElse(VersionCompatibility.Strict)
+          .getOrElse {
+            val m = module.name.value
+            if (
+              m.endsWith("_2.11") || m
+                .endsWith("_2.12") || m.endsWith("_2.13") || m.endsWith("_3")
+            )
+              VersionCompatibility.PackVer
+            else VersionCompatibility.EarlySemVer
+          }
       versions = reconcileVersions(deps, compat)
       dep <- deps
       reconciledVersion <- versions.get(dep)

--- a/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
@@ -9,7 +9,7 @@ class ExportCommandSuite extends tests.BaseSuite {
        |""".stripMargin,
     expectedOutput =
       """|/workingDirectory/3rdparty.yaml:3:16 error: transitive dependency 'com.google.guava:guava' has conflicting versions.
-         |    resolved versions: "27.1-jre"
+         |    found versions: "27.1-jre"
          |    declared versions: "29.0-jre"
          |    root dependencies:
          |  To fix this problem, add 'dependencies = ''' to the root dependencies OR add 'targets' to the transitive dependency.


### PR DESCRIPTION
`VersionCompatibility.Strict` generates a lot of false positives in the linter.
As a first go around, I'm putting in the similar assumption as sbt's eviction warning (semver-early for Java, and pvp for Scala)