### PR TITLE
Lint improvements

### DIFF
--- a/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
@@ -9,9 +9,13 @@ class ExportCommandSuite extends tests.BaseSuite {
        |""".stripMargin,
     expectedOutput =
       """|/workingDirectory/3rdparty.yaml:3:16 error: transitive dependency 'com.google.guava:guava' has conflicting versions.
-         |    found versions: "27.1-jre"
-         |    declared versions: "29.0-jre"
-         |    root dependencies:
+         |       found versions: 27.1-jre
+         |    declared versions: 29.0-jre
+         |      popular version: 29.0-jre
+         |              ok deps: com.google.guava:guava:29.0-jre
+         |           ok targets:
+         |       unpopular deps: org.eclipse.lsp4j:org.eclipse.lsp4j:0.9.0
+         |    unpopular targets:
          |  To fix this problem, add 'dependencies = ''' to the root dependencies OR add 'targets' to the transitive dependency.
          |  - dependency: com.google.guava:guava:29.0-jre
          |                ^""".stripMargin,


### PR DESCRIPTION
1. Fixed root dependencies lookup by using `index.roots`
2. Given the conflicting versions, do a popularity vote, then pick
  latest as tie-breaker
3. Print the full list of non-popular target paths (3rdparty/jvm/...)
