### PR TITLE
Create scala_import for evicted artifacts 

### DIFF
--- a/multideps/src/main/scala/multideps/commands/ExportCommand.scala
+++ b/multideps/src/main/scala/multideps/commands/ExportCommand.scala
@@ -144,8 +144,6 @@ case class ExportCommand(
       index: ResolutionIndex,
       cache: FileCache[Task]
   ): Result[Path] = {
-    // if  Resolution.defaultTypes.contains(p.`type`) &&
-    //  d.version == index.reconciledVersion(d) =>
     val resolvedArtifacts = index.unevictedArtifacts
     val outputIndex: mutable.Map[String, ArtifactOutput] =
       collection.concurrent.TrieMap.empty[String, ArtifactOutput]

--- a/multideps/src/main/scala/multideps/commands/ExportCommand.scala
+++ b/multideps/src/main/scala/multideps/commands/ExportCommand.scala
@@ -146,7 +146,7 @@ case class ExportCommand(
   ): Result[Path] = {
     // if  Resolution.defaultTypes.contains(p.`type`) &&
     //  d.version == index.reconciledVersion(d) =>
-    val resolvedArtifacts = index.resolvedArtifacts
+    val resolvedArtifacts = index.unevictedArtifacts
     val outputIndex: mutable.Map[String, ArtifactOutput] =
       collection.concurrent.TrieMap.empty[String, ArtifactOutput]
     val progressBar =
@@ -247,7 +247,7 @@ case class ExportCommand(
 
   def lintPostResolution(index: ResolutionIndex): Result[Unit] = {
     val errors = for {
-      (module, deps) <- index.artifacts.toList
+      (module, deps) <- index.allDependencies.toList
       allVersions = deps.map(d => index.reconciledVersion(d))
       if allVersions.size > 1
       diagnostic <- index.thirdparty.depsByModule.get(module) match {

--- a/multideps/src/main/scala/multideps/diagnostics/MultidepsEnrichments.scala
+++ b/multideps/src/main/scala/multideps/diagnostics/MultidepsEnrichments.scala
@@ -63,6 +63,23 @@ object MultidepsEnrichments {
       repr.replaceAll("[^a-zA-Z0-9-\\.]", "_") + classifierRepr
     }
 
+    def mavenLabel: String = {
+      val org = dep.module.organization.value
+      val moduleName = dep.module.name.value
+      val version = dep.version
+      val classifierOrConfigRepr: String =
+        if (dep.publication.classifier.nonEmpty)
+          s"_${dep.publication.classifier.value}"
+        else if (dep.configuration.nonEmpty)
+          dep.configuration.value match {
+            case "default" => ""
+            case config => s"_$config"
+          }
+        else ""
+
+      s"@maven//:${org}/${moduleName}-${version}${classifierOrConfigRepr}.jar"
+    }
+
     def withoutConfig: Dependency =
       dep.withConfiguration(Configuration.empty)
   }

--- a/multideps/src/main/scala/multideps/diagnostics/MultidepsEnrichments.scala
+++ b/multideps/src/main/scala/multideps/diagnostics/MultidepsEnrichments.scala
@@ -62,6 +62,9 @@ object MultidepsEnrichments {
       // Bazel workspace names may contain only A-Z, a-z, 0-9, '-', '_' and '.'
       repr.replaceAll("[^a-zA-Z0-9-\\.]", "_") + classifierRepr
     }
+
+    def withoutConfig: Dependency =
+      dep.withConfiguration(Configuration.empty)
   }
   implicit class XtensionSeq[A](xs: Seq[A]) {
     def sortByCachedFunction[B: Ordering](fn: A => B): Seq[A] = {

--- a/multideps/src/main/scala/multideps/outputs/ArtifactOutput.scala
+++ b/multideps/src/main/scala/multideps/outputs/ArtifactOutput.scala
@@ -26,16 +26,6 @@ final case class ArtifactOutput(
     if (dependency.publication.classifier.nonEmpty)
       s"_${dependency.publication.classifier.value}"
     else ""
-  val configRepr: String =
-    if (dependency.publication.classifier.nonEmpty)
-      s"_${dependency.publication.classifier.value}"
-    else if (dependency.configuration.nonEmpty)
-      dependency.configuration.value match {
-        case "default" => ""
-        case config => s"_$config"
-      }
-    else ""
-
   val label: String = dependency.bazelLabel
   val repr: String =
     s"""|Artifact(
@@ -43,12 +33,10 @@ final case class ArtifactOutput(
         |  url = "${artifact.url}",
         |  sha = "${artifactSha256}"
         |)""".stripMargin
-  val org = dependency.module.organization.value
-  val moduleName = dependency.module.name.value
-  val version = dependency.version
-  // pprint.log(dependency.configRepr)
-  val mavenLabel: String =
-    s"@maven//:${org}/${moduleName}-${version}${configRepr}.jar"
+  val org: String = dependency.module.organization.value
+  val moduleName: String = dependency.module.name.value
+  val version: String = dependency.version
+  val mavenLabel: String = dependency.mavenLabel
 
   def httpFile: TargetOutput =
     TargetOutput(
@@ -120,5 +108,31 @@ object ArtifactOutput {
 
     genrule.toDoc /
       scalaImport.toDoc
+  }
+
+  def buildEvictedDoc(
+      dep: Dependency,
+      winner: String,
+      index: ResolutionIndex,
+      outputIndex: collection.Map[String, ArtifactOutput]
+  ): Doc = {
+    val depsRef: Seq[String] = Seq(
+      dep.withoutConfig.withVersion(winner).bazelLabel
+    )
+    def scalaImport: TargetOutput =
+      TargetOutput(
+        kind = "scala_import",
+        "name" -> Docs.literal(dep.bazelLabel),
+        "jars" -> Docs.array(),
+        "deps" -> Docs.array(depsRef: _*),
+        "exports" -> Docs.array(depsRef: _*),
+        "tags" -> Docs.array(
+          s"jvm_module=${dep.module.repr}",
+          s"jvm_version=${dep.version}",
+          s"evicted=True"
+        ),
+        "visibility" -> Docs.array("//visibility:public")
+      )
+    scalaImport.toDoc
   }
 }

--- a/multideps/src/main/scala/multideps/outputs/ArtifactOutput.scala
+++ b/multideps/src/main/scala/multideps/outputs/ArtifactOutput.scala
@@ -82,12 +82,12 @@ object ArtifactOutput {
       rawDependencies.iterator
         .flatMap(d =>
           // todo: reconciledDependency could be questionable
-          // outputIndex.get(index.reconciledDependency(d).repr))
-          outputIndex.get(d.repr) match {
+          outputIndex.get(index.reconciledDependency(d).repr) match {
             case Some(x) => Some(x)
             case _ =>
+              val recon = index.reconciledDependency(d)
               println(
-                s"[warn] ${d.repr} (called by $label) is missing from `outputs`"
+                s"[warn] ${recon.repr} (originally ${d.repr} called by $label) is missing from `outputs`"
               )
               // sys.error(s"${d.repr} is missing from `outputs`")
               None

--- a/multideps/src/main/scala/multideps/outputs/ResolutionIndex.scala
+++ b/multideps/src/main/scala/multideps/outputs/ResolutionIndex.scala
@@ -75,6 +75,7 @@ final case class ResolutionIndex(
     dep.withVersion(reconciledVersion(dep))
   def reconciledVersion(dep: Dependency): String =
     reconciledVersions.getOrElse(dep.withoutConfig, dep.version)
+  def evictionPairs: Seq[(Dependency, String)] = reconciledVersions.toSeq
 
   // the map between evicted dependencies and their resolved versions
   private lazy val reconciledVersions: Map[Dependency, String] = {

--- a/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
@@ -3,10 +3,15 @@ package tests.commands
 class ExportCommandSuite extends tests.BaseSuite {
 
   checkDeps(
-    "duplicate",
+    "evicted artifacts do not create genrules",
     s"""|  - dependency: org.slf4j:slf4j-log4j12:1.6.1
         |  - dependency: org.slf4j:slf4j-log4j12:1.6.4
-        |""".stripMargin
+        |""".stripMargin,
+    queryArg = allGenrules,
+    expectedQuery = """|@maven//:genrules/log4j_log4j_1.2.16
+                       |@maven//:genrules/org.slf4j_slf4j-api_1.6.4
+                       |@maven//:genrules/org.slf4j_slf4j-log4j12_1.6.4
+                       |""".stripMargin
   )
 
   checkDeps(

--- a/tests/src/test/scala/tests/commands/ResolutionTest.scala
+++ b/tests/src/test/scala/tests/commands/ResolutionTest.scala
@@ -1,0 +1,45 @@
+package tests.commands
+
+import multideps.outputs.ResolutionIndex
+
+import coursier.core.Dependency
+import coursier.core.Module
+import coursier.core.ModuleName
+import coursier.core.Organization
+import coursier.version.VersionCompatibility
+
+class ResolutionTest extends tests.BaseSuite {
+  test("reconciliation") {
+    val vs = ResolutionIndex.reconcileVersions(
+      Set(
+        jodaTime("2.10.4"),
+        jodaTime("2.8.1"),
+        jodaTime("2.9.9"),
+        jodaTime("2.8.2"),
+        jodaTime("[2.0,)"),
+        jodaTime("2.1"),
+        jodaTime("1.6.2"),
+        jodaTime("2.9.4"),
+        jodaTime("2.3"),
+        jodaTime("2.10.1"),
+        jodaTime("2.10.7"),
+        jodaTime("2.9.2"),
+        jodaTime("2.10.6"),
+        jodaTime("2.9.3"),
+        jodaTime("2.10.8"),
+        jodaTime("2.10.5"),
+        jodaTime("2.9.5")
+      ),
+      VersionCompatibility.EarlySemVer
+    )
+    println(vs map { case (k, v) => (k.version, v)  })
+    assertEquals(vs.values.head, "2.10.8")
+    assert(vs.values.toList.distinct.size == 1)
+  }
+
+  def jodaTime(v: String): Dependency =
+    Dependency(
+      Module(Organization("joda-time"), ModuleName("joda-time"), Map.empty),
+      v
+    )
+}

--- a/tests/src/test/scala/tests/commands/ResolutionTest.scala
+++ b/tests/src/test/scala/tests/commands/ResolutionTest.scala
@@ -32,7 +32,6 @@ class ResolutionTest extends tests.BaseSuite {
       ),
       VersionCompatibility.EarlySemVer
     )
-    println(vs map { case (k, v) => (k.version, v)  })
     assertEquals(vs.values.head, "2.10.8")
     assert(vs.values.toList.distinct.size == 1)
   }


### PR DESCRIPTION
For maintaining Pants semantics when building Pants, create delegate `scala_import` rules for the evicted dependencies. This will bump the artifacts to the latest version within the compatibility constraint.