### PR TITLE
Re-fix the missing transitive

### DIFF
--- a/multideps/src/main/scala/multideps/diagnostics/MultidepsEnrichments.scala
+++ b/multideps/src/main/scala/multideps/diagnostics/MultidepsEnrichments.scala
@@ -4,6 +4,8 @@ import java.{util => ju}
 
 import scala.collection.mutable
 
+import multideps.resolvers.DependencyId
+
 import coursier.core.Configuration
 import coursier.core.Dependency
 import coursier.error.ResolutionError
@@ -79,6 +81,15 @@ object MultidepsEnrichments {
 
       s"@maven//:${org}/${moduleName}-${version}${classifierOrConfigRepr}.jar"
     }
+
+    def toDependencyId: DependencyId =
+      DependencyId(
+        dep.module.organization.value,
+        dep.module.name.value,
+        dep.version,
+        if (isEmptyConfiguration(dep.configuration)) None
+        else Some(dep.configuration.value)
+      )
 
     def withoutConfig: Dependency =
       dep.withConfiguration(Configuration.empty)

--- a/multideps/src/main/scala/multideps/outputs/ArtifactOutput.scala
+++ b/multideps/src/main/scala/multideps/outputs/ArtifactOutput.scala
@@ -54,8 +54,6 @@ object ArtifactOutput {
       outputIndex: collection.Map[String, ArtifactOutput]
   ): Doc = {
     import o._
-    // only include dependencies for the root-level dependencies
-    // otherwise the transitive artifact would end up pulling too many things
     val rawDependencies =
       if (
         dependency.module.organization.value == config.organization.value
@@ -65,7 +63,7 @@ object ArtifactOutput {
         index.dependencies
           .getOrElse(config.toId, Nil)
           .filterNot(_ == dependency)
-      else Nil
+      else index.maybeDependencies(dependency)
     val depsRef: Seq[String] =
       rawDependencies.iterator
         .flatMap(d =>

--- a/multideps/src/main/scala/multideps/outputs/ResolutionIndex.scala
+++ b/multideps/src/main/scala/multideps/outputs/ResolutionIndex.scala
@@ -57,6 +57,23 @@ final case class ResolutionIndex(
     }
     res.toMap
   }
+
+  // we need this function beause some versions are pulled in
+  // as transitive dependencies of others, and it doesn't contain
+  // its own dependency information
+  def maybeDependencies(dep: Dependency): Seq[Dependency] = {
+    val allVersions = allDependencies
+      .get(dep.module)
+      .getOrElse(Nil)
+      .map(_.toDependencyId)
+    allVersions.find(v => dependencies.getOrElse(v, Nil).nonEmpty) match {
+      case Some(v) =>
+        // remove self-edge
+        dependencies(v).filterNot(d => d.module == dep.module)
+      case _ => Nil
+    }
+  }
+
   val allDependencies: collection.Map[Module, collection.Set[Dependency]] = {
     val result =
       mutable.LinkedHashMap.empty[Module, mutable.LinkedHashSet[Dependency]]


### PR DESCRIPTION
Bringing reconciled version in #10 broke what I previously fixed in 920deab80c7826e19db231f6c6328f4b80bc3f0e.
This combines the good parts of both so we would have both version resolution and the dependencies.

Without this, tests would fail because bytebuddy would be missing from mockito-core etc.